### PR TITLE
SmartMotorTelemetryConfig

### DIFF
--- a/src/main/java/frc/robot/subsystems/ArmSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/ArmSubsystem.java
@@ -32,6 +32,11 @@ public class ArmSubsystem extends SubsystemBase
 {
 
   private final TalonFXS                   armMotor    = new TalonFXS(1);//, MotorType.kBrushless);
+//  private final SmartMotorControllerTelemetryConfig motorTelemetryConfig = new SmartMotorControllerTelemetryConfig()
+//          .withMechanismPosition()
+//          .withRotorPosition()
+//          .withMechanismLowerLimit()
+//          .withMechanismUpperLimit();
   private final SmartMotorControllerConfig motorConfig = new SmartMotorControllerConfig(this)
       .withClosedLoopController(4, 0, 0, DegreesPerSecond.of(180), DegreesPerSecondPerSecond.of(90))
       .withSoftLimit(Degrees.of(-30), Degrees.of(100))
@@ -39,6 +44,7 @@ public class ArmSubsystem extends SubsystemBase
 //      .withExternalEncoder(armMotor.getAbsoluteEncoder())
       .withIdleMode(MotorMode.BRAKE)
       .withTelemetry("ArmMotor", TelemetryVerbosity.HIGH)
+//      .withSpecificTelemetry("ArmMotor", motorTelemetryConfig)
       .withStatorCurrentLimit(Amps.of(40))
 //      .withVoltageCompensation(Volts.of(12))
       .withMotorInverted(false)

--- a/src/main/java/frc/robot/subsystems/ElevatorSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/ElevatorSubsystem.java
@@ -28,11 +28,17 @@ import yams.motorcontrollers.SmartMotorControllerConfig.ControlMode;
 import yams.motorcontrollers.SmartMotorControllerConfig.MotorMode;
 import yams.motorcontrollers.SmartMotorControllerConfig.TelemetryVerbosity;
 import yams.motorcontrollers.local.SparkWrapper;
+import yams.telemetry.SmartMotorControllerTelemetryConfig;
 
 public class ElevatorSubsystem extends SubsystemBase
 {
 
   private final SparkMax                   elevatorMotor = new SparkMax(2, MotorType.kBrushless);
+//  private final SmartMotorControllerTelemetryConfig motorTelemetryConfig = new SmartMotorControllerTelemetryConfig()
+//          .withMechanismPosition()
+//          .withRotorPosition()
+//          .withMechanismLowerLimit()
+//          .withMechanismUpperLimit();
   private final SmartMotorControllerConfig motorConfig   = new SmartMotorControllerConfig(this)
       .withMechanismCircumference(Meters.of(Inches.of(0.25).in(Meters) * 22))
       .withClosedLoopController(4, 0, 0, MetersPerSecond.of(0.5), MetersPerSecondPerSecond.of(0.5))
@@ -41,6 +47,7 @@ public class ElevatorSubsystem extends SubsystemBase
 //      .withExternalEncoder(armMotor.getAbsoluteEncoder())
       .withIdleMode(MotorMode.BRAKE)
       .withTelemetry("ElevatorMotor", TelemetryVerbosity.HIGH)
+//      .withSpecificTelemetry("ElevatorMotor", motorTelemetryConfig)
       .withStatorCurrentLimit(Amps.of(40))
       .withVoltageCompensation(Volts.of(12))
       .withMotorInverted(false)

--- a/src/main/java/frc/robot/subsystems/TurretSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/TurretSubsystem.java
@@ -25,18 +25,25 @@ import yams.motorcontrollers.SmartMotorControllerConfig.ControlMode;
 import yams.motorcontrollers.SmartMotorControllerConfig.MotorMode;
 import yams.motorcontrollers.SmartMotorControllerConfig.TelemetryVerbosity;
 import yams.motorcontrollers.remote.TalonFXSWrapper;
+import yams.telemetry.SmartMotorControllerTelemetryConfig;
 
 public class TurretSubsystem extends SubsystemBase
 {
 
   private final TalonFXS                   turretMotor = new TalonFXS(1);//, MotorType.kBrushless);
+//  private final SmartMotorControllerTelemetryConfig motorTelemetryConfig = new SmartMotorControllerTelemetryConfig()
+//          .withMechanismPosition()
+//          .withRotorPosition()
+//          .withMechanismLowerLimit()
+//          .withMechanismUpperLimit();
   private final SmartMotorControllerConfig motorConfig = new SmartMotorControllerConfig(this)
       .withClosedLoopController(4, 0, 0, DegreesPerSecond.of(180), DegreesPerSecondPerSecond.of(90))
       .withSoftLimit(Degrees.of(-30), Degrees.of(100))
       .withGearing(gearing(gearbox(3, 4)))
 //      .withExternalEncoder(armMotor.getAbsoluteEncoder())
       .withIdleMode(MotorMode.BRAKE)
-      .withTelemetry("ArmMotor", TelemetryVerbosity.HIGH)
+      .withTelemetry("TurretMotor", TelemetryVerbosity.HIGH)
+//      .withSpecificTelemetry("TurretMotor", motorTelemetryConfig)
       .withStatorCurrentLimit(Amps.of(40))
 //      .withVoltageCompensation(Volts.of(12))
       .withMotorInverted(false)

--- a/src/main/java/yams/motorcontrollers/SmartMotorController.java
+++ b/src/main/java/yams/motorcontrollers/SmartMotorController.java
@@ -31,6 +31,7 @@ import java.util.Optional;
 import yams.exceptions.SmartMotorControllerConfigurationException;
 import yams.gearing.MechanismGearing;
 import yams.telemetry.SmartMotorControllerTelemetry;
+import yams.telemetry.SmartMotorControllerTelemetryConfig;
 
 public abstract class SmartMotorController
 {
@@ -38,39 +39,43 @@ public abstract class SmartMotorController
   /**
    * Telemetry.
    */
-  protected SmartMotorControllerTelemetry   telemetry                  = new SmartMotorControllerTelemetry();
+  protected SmartMotorControllerTelemetry                 telemetry                  = new SmartMotorControllerTelemetry();
   /**
    * {@link SmartMotorControllerConfig} for the motor.
    */
-  protected SmartMotorControllerConfig      config;
+  protected SmartMotorControllerConfig                    config;
   /**
    * Profiled PID controller for the motor controller.
    */
-  protected Optional<ProfiledPIDController> pidController              = Optional.empty();
+  protected Optional<ProfiledPIDController>               pidController              = Optional.empty();
   /**
    * Simple PID controller for the motor controller.
    */
-  protected Optional<PIDController>         simplePidController        = Optional.empty();
+  protected Optional<PIDController>                       simplePidController        = Optional.empty();
   /**
    * Setpoint position
    */
-  protected Optional<Angle>                 setpointPosition           = Optional.empty();
+  protected Optional<Angle>                               setpointPosition           = Optional.empty();
   /**
    * Setpoint velocity.
    */
-  protected Optional<AngularVelocity>       setpointVelocity           = Optional.empty();
+  protected Optional<AngularVelocity>                     setpointVelocity           = Optional.empty();
   /**
    * Thread of the closed loop controller.
    */
-  protected Notifier                        closedLoopControllerThread = null;
+  protected Notifier                                      closedLoopControllerThread = null;
   /**
    * Parent table for telemetry.
    */
-  protected Optional<NetworkTable>          parentTable                = Optional.empty();
+  protected Optional<NetworkTable>                        parentTable                = Optional.empty();
   /**
    * {@link SmartMotorController} telemetry table.
    */
-  protected Optional<NetworkTable>          telemetryTable             = Optional.empty();
+  protected Optional<NetworkTable>                        telemetryTable             = Optional.empty();
+  /**
+   * Config for publishing specific telemetry.
+   */
+  protected Optional<SmartMotorControllerTelemetryConfig> telemetryConfig            = Optional.empty();
 
 
   /**
@@ -561,7 +566,10 @@ public abstract class SmartMotorController
         telemetry.distance = getMeasurementPosition();
         telemetry.linearVelocity = getMeasurementVelocity();
       }
-      telemetry.publish(telemetryTable.get(), config.getVerbosity().get());
+      config.getSmartControllerTelemetryConfig().ifPresentOrElse(
+              telemetryConfig ->
+                      telemetry.publishFromConfig(telemetryTable.get(), ((SmartMotorControllerTelemetryConfig) telemetryConfig)),
+              () -> telemetry.publish(telemetryTable.get(), config.getVerbosity().get()));
     }
   }
 

--- a/src/main/java/yams/motorcontrollers/SmartMotorControllerConfig.java
+++ b/src/main/java/yams/motorcontrollers/SmartMotorControllerConfig.java
@@ -478,20 +478,6 @@ public class SmartMotorControllerConfig
     return this;
   }
 
-  /**
-   * Set the telemetry for the {@link SmartMotorController} with a {@link SmartMotorControllerTelemetryConfig}
-   * {@link TelemetryVerbosity} defaults to HIGH.
-   *
-   * @param telemetryConfig Config that specifies what to log.
-   * @return {@link SmartMotorControllerConfig} for chaining.
-   */
-  public SmartMotorControllerConfig withSpecificTelemetry(SmartMotorControllerTelemetryConfig telemetryConfig) {
-    this.telemetryName = Optional.of("motor");
-    this.verbosity = Optional.of(TelemetryVerbosity.HIGH);
-    this.specifiedTelemetryConfig = telemetryConfig == null ? Optional.empty() : Optional.of(telemetryConfig);
-    return this;
-  }
-
   public Optional<Object> getSmartControllerTelemetryConfig() {
     return specifiedTelemetryConfig;
   }

--- a/src/main/java/yams/motorcontrollers/SmartMotorControllerConfig.java
+++ b/src/main/java/yams/motorcontrollers/SmartMotorControllerConfig.java
@@ -33,6 +33,7 @@ import java.util.OptionalInt;
 import yams.exceptions.SmartMotorControllerConfigurationException;
 import yams.gearing.GearBox;
 import yams.gearing.MechanismGearing;
+import yams.telemetry.SmartMotorControllerTelemetryConfig;
 
 /**
  * Smart motor controller config.
@@ -133,6 +134,10 @@ public class SmartMotorControllerConfig
    * Telemetry verbosity setting.
    */
   private Optional<TelemetryVerbosity>      verbosity                          = Optional.empty();
+  /**
+   * Optional config for custom telemetry setup.
+   */
+  private Optional<Object>                  specifiedTelemetryConfig           = Optional.empty();
   /**
    * Zero offset of the {@link SmartMotorController}
    */
@@ -457,6 +462,38 @@ public class SmartMotorControllerConfig
     this.telemetryName = Optional.of("motor");
     this.verbosity = Optional.of(verbosity);
     return this;
+  }
+
+  /**
+   * Set the telemetry for the {@link SmartMotorController} with a {@link SmartMotorControllerTelemetryConfig}
+   *
+   * @param telemetryName Name for the {@link SmartMotorController}
+   * @param telemetryConfig Config that specifies what to log.
+   * @return {@link SmartMotorControllerConfig} for chaining.
+   */
+  public SmartMotorControllerConfig withSpecificTelemetry(String telemetryName, SmartMotorControllerTelemetryConfig telemetryConfig) {
+    this.telemetryName = telemetryName == null ? Optional.empty() : Optional.of(telemetryName);
+    this.verbosity = Optional.of(TelemetryVerbosity.HIGH);
+    this.specifiedTelemetryConfig = telemetryConfig == null ? Optional.empty() : Optional.of(telemetryConfig);
+    return this;
+  }
+
+  /**
+   * Set the telemetry for the {@link SmartMotorController} with a {@link SmartMotorControllerTelemetryConfig}
+   * {@link TelemetryVerbosity} defaults to HIGH.
+   *
+   * @param telemetryConfig Config that specifies what to log.
+   * @return {@link SmartMotorControllerConfig} for chaining.
+   */
+  public SmartMotorControllerConfig withSpecificTelemetry(SmartMotorControllerTelemetryConfig telemetryConfig) {
+    this.telemetryName = Optional.of("motor");
+    this.verbosity = Optional.of(TelemetryVerbosity.HIGH);
+    this.specifiedTelemetryConfig = telemetryConfig == null ? Optional.empty() : Optional.of(telemetryConfig);
+    return this;
+  }
+
+  public Optional<Object> getSmartControllerTelemetryConfig() {
+    return specifiedTelemetryConfig;
   }
 
   /**

--- a/src/main/java/yams/telemetry/SmartMotorControllerTelemetry.java
+++ b/src/main/java/yams/telemetry/SmartMotorControllerTelemetry.java
@@ -1,25 +1,15 @@
 package yams.telemetry;
 
-import static edu.wpi.first.units.Units.Celsius;
-import static edu.wpi.first.units.Units.Fahrenheit;
-import static edu.wpi.first.units.Units.Meters;
-import static edu.wpi.first.units.Units.MetersPerSecond;
-import static edu.wpi.first.units.Units.Rotations;
-import static edu.wpi.first.units.Units.RotationsPerSecond;
-
 import edu.wpi.first.networktables.BooleanPublisher;
 import edu.wpi.first.networktables.DoublePublisher;
 import edu.wpi.first.networktables.NetworkTable;
-import edu.wpi.first.units.measure.Angle;
-import edu.wpi.first.units.measure.AngularVelocity;
-import edu.wpi.first.units.measure.Distance;
-import edu.wpi.first.units.measure.LinearVelocity;
-import edu.wpi.first.units.measure.Temperature;
+import edu.wpi.first.units.measure.*;
 import yams.motorcontrollers.SmartMotorController;
 import yams.motorcontrollers.SmartMotorControllerConfig.TelemetryVerbosity;
 
-public class SmartMotorControllerTelemetry
-{
+import static edu.wpi.first.units.Units.*;
+
+public class SmartMotorControllerTelemetry {
 
   /**
    * Mechanism lower limit reached.

--- a/src/main/java/yams/telemetry/SmartMotorControllerTelemetry.java
+++ b/src/main/java/yams/telemetry/SmartMotorControllerTelemetry.java
@@ -184,62 +184,199 @@ public class SmartMotorControllerTelemetry {
    */
   private DoublePublisher  rotorVelocityPublisher;
 
-  /**
-   * Publish {@link SmartMotorController} telemetry to {@link NetworkTable}
-   *
-   * @param publishTable {@link NetworkTable} to publish to.
-   * @param verbosity    {@link TelemetryVerbosity} to publish.
-   */
-  public void publish(NetworkTable publishTable, TelemetryVerbosity verbosity)
-  {
-    if (!publishTable.equals(this.table))
-    {
-      table = publishTable;
-      mechanismLowerLimitPublisher = table.getBooleanTopic("Mechanism Lower Limit").publish();
-      mechanismUpperLimitPublisher = table.getBooleanTopic("Mechanism Upper Limit").publish();
-      temperatureLimitPublisher = table.getBooleanTopic("Temperature Limit").publish();
-      velocityControlPublisher = table.getBooleanTopic("Velocity Control").publish();
-      elevatorFeedforwardPublisher = table.getBooleanTopic("Elevator Feedforward").publish();
-      armFeedforwardPublisher = table.getBooleanTopic("Arm Feedforward").publish();
-      simpleFeedforwardPublisher = table.getBooleanTopic("Simple Feedforward").publish();
-      motionProfilePublisher = table.getBooleanTopic("Motion Profile").publish();
-      setpointPositionPublisher = table.getDoubleTopic("Setpoint Position (Rotations)").publish();
-      setpointVelocityPublisher = table.getDoubleTopic("Setpoint Velocity (Rotations per Second)").publish();
-      feedforwardVoltagePublisher = table.getDoubleTopic("Feedforward Voltage").publish();
-      pidOutputVoltagePublisher = table.getDoubleTopic("PID Output (Voltage)").publish();
-      outputVoltagePublisher = table.getDoubleTopic("Motor Output Voltage").publish();
-      statorCurrentPublisher = table.getDoubleTopic("Stator Current (Amps)").publish();
-      temperaturePublisher = table.getDoubleTopic("Temperature (Celsius)").publish();
-      measurementPositionPublisher = table.getDoubleTopic("Measurement Position (Meters)").publish();
-      measurementVelocityPublisher = table.getDoubleTopic("Measurement Velocity (Meters per Second)").publish();
-      mechanismPositionPublisher = table.getDoubleTopic("Mechanism Position (Rotations)").publish();
-      mechanismVelocityPublisher = table.getDoubleTopic("Mechanism Velocity (Rotations per Second)").publish();
-      rotorPositionPublisher = table.getDoubleTopic("Rotor Position (Rotations)").publish();
-      rotorVelocityPublisher = table.getDoubleTopic("Rotor Velocity (Rotations per Second)").publish();
+    /**
+     * Publish {@link SmartMotorController} telemetry to {@link NetworkTable}
+     *
+     * @param publishTable {@link NetworkTable} to publish to.
+     * @param verbosity    {@link TelemetryVerbosity} to publish.
+     */
+    public void publish(NetworkTable publishTable, TelemetryVerbosity verbosity) {
+        if (!publishTable.equals(this.table)) {
+            table = publishTable;
+            mechanismLowerLimitPublisher = table.getBooleanTopic("Mechanism Lower Limit").publish();
+            mechanismUpperLimitPublisher = table.getBooleanTopic("Mechanism Upper Limit").publish();
+            temperatureLimitPublisher = table.getBooleanTopic("Temperature Limit").publish();
+            velocityControlPublisher = table.getBooleanTopic("Velocity Control").publish();
+            elevatorFeedforwardPublisher = table.getBooleanTopic("Elevator Feedforward").publish();
+            armFeedforwardPublisher = table.getBooleanTopic("Arm Feedforward").publish();
+            simpleFeedforwardPublisher = table.getBooleanTopic("Simple Feedforward").publish();
+            motionProfilePublisher = table.getBooleanTopic("Motion Profile").publish();
+            setpointPositionPublisher = table.getDoubleTopic("Setpoint Position (Rotations)").publish();
+            setpointVelocityPublisher = table.getDoubleTopic("Setpoint Velocity (Rotations per Second)").publish();
+            feedforwardVoltagePublisher = table.getDoubleTopic("Feedforward Voltage").publish();
+            pidOutputVoltagePublisher = table.getDoubleTopic("PID Output (Voltage)").publish();
+            outputVoltagePublisher = table.getDoubleTopic("Motor Output Voltage").publish();
+            statorCurrentPublisher = table.getDoubleTopic("Stator Current (Amps)").publish();
+            temperaturePublisher = table.getDoubleTopic("Temperature (Celsius)").publish();
+            measurementPositionPublisher = table.getDoubleTopic("Measurement Position (Meters)").publish();
+            measurementVelocityPublisher = table.getDoubleTopic("Measurement Velocity (Meters per Second)").publish();
+            mechanismPositionPublisher = table.getDoubleTopic("Mechanism Position (Rotations)").publish();
+            mechanismVelocityPublisher = table.getDoubleTopic("Mechanism Velocity (Rotations per Second)").publish();
+            rotorPositionPublisher = table.getDoubleTopic("Rotor Position (Rotations)").publish();
+            rotorVelocityPublisher = table.getDoubleTopic("Rotor Velocity (Rotations per Second)").publish();
+        }
+        if (table != null) {
+            mechanismLowerLimitPublisher.set(mechanismLowerLimit);
+            mechanismUpperLimitPublisher.set(mechanismUpperLimit);
+            temperatureLimitPublisher.set(temperatureLimit);
+            velocityControlPublisher.set(velocityControl);
+            elevatorFeedforwardPublisher.set(elevatorFeedforward);
+            armFeedforwardPublisher.set(armFeedforward);
+            simpleFeedforwardPublisher.set(simpleFeedforward);
+            motionProfilePublisher.set(motionProfile);
+            setpointPositionPublisher.set(setpointPosition);
+            setpointVelocityPublisher.set(setpointVelocity);
+            feedforwardVoltagePublisher.set(feedforwardVoltage);
+            pidOutputVoltagePublisher.set(pidOutputVoltage);
+            outputVoltagePublisher.set(outputVoltage);
+            statorCurrentPublisher.set(statorCurrent);
+            temperaturePublisher.set(temperature.in(Celsius));
+            measurementPositionPublisher.set(distance.in(Meters));
+            measurementVelocityPublisher.set(linearVelocity.in(MetersPerSecond));
+            mechanismPositionPublisher.set(mechanismPosition.in(Rotations));
+            mechanismVelocityPublisher.set(mechanismVelocity.in(RotationsPerSecond));
+            rotorPositionPublisher.set(rotorPosition.in(Rotations));
+            rotorVelocityPublisher.set(rotorVelocity.in(RotationsPerSecond));
+        }
     }
-    if (table != null)
-    {
-      mechanismLowerLimitPublisher.set(mechanismLowerLimit);
-      mechanismUpperLimitPublisher.set(mechanismUpperLimit);
-      temperatureLimitPublisher.set(temperatureLimit);
-      velocityControlPublisher.set(velocityControl);
-      elevatorFeedforwardPublisher.set(elevatorFeedforward);
-      armFeedforwardPublisher.set(armFeedforward);
-      simpleFeedforwardPublisher.set(simpleFeedforward);
-      motionProfilePublisher.set(motionProfile);
-      setpointPositionPublisher.set(setpointPosition);
-      setpointVelocityPublisher.set(setpointVelocity);
-      feedforwardVoltagePublisher.set(feedforwardVoltage);
-      pidOutputVoltagePublisher.set(pidOutputVoltage);
-      outputVoltagePublisher.set(outputVoltage);
-      statorCurrentPublisher.set(statorCurrent);
-      temperaturePublisher.set(temperature.in(Celsius));
-      measurementPositionPublisher.set(distance.in(Meters));
-      measurementVelocityPublisher.set(linearVelocity.in(MetersPerSecond));
-      mechanismPositionPublisher.set(mechanismPosition.in(Rotations));
-      mechanismVelocityPublisher.set(mechanismVelocity.in(RotationsPerSecond));
-      rotorPositionPublisher.set(rotorPosition.in(Rotations));
-      rotorVelocityPublisher.set(rotorVelocity.in(RotationsPerSecond));
+
+    /**
+     * Publish {@link SmartMotorController} telemetry to {@link NetworkTable} using a given {@link SmartMotorControllerTelemetryConfig}
+     *
+     * @param publishTable {@link NetworkTable} to publish to.
+     * @param config       {@link SmartMotorControllerTelemetryConfig} to publish from.
+     */
+    public void publishFromConfig(NetworkTable publishTable, SmartMotorControllerTelemetryConfig config) {
+        if (!publishTable.equals(this.table)) {
+            table = publishTable;
+            if (config.mechanismLowerLimitEnabled) {
+              mechanismLowerLimitPublisher = table.getBooleanTopic("Mechanism Lower Limit").publish();
+            }
+            if (config.mechanismUpperLimitEnabled) {
+              mechanismUpperLimitPublisher = table.getBooleanTopic("Mechanism Upper Limit").publish();
+            }
+            if (config.temperatureLimitEnabled) {
+              temperatureLimitPublisher = table.getBooleanTopic("Temperature Limit").publish();
+            }
+            if (config.velocityControlEnabled) {
+              velocityControlPublisher = table.getBooleanTopic("Velocity Control").publish();
+            }
+            if (config.elevatorFeedforwardEnabled) {
+              elevatorFeedforwardPublisher = table.getBooleanTopic("Elevator Feedforward").publish();
+            }
+            if (config.armFeedforwardEnabled) {
+              armFeedforwardPublisher = table.getBooleanTopic("Arm Feedforward").publish();
+            }
+            if (config.simpleFeedforwardEnabled) {
+              simpleFeedforwardPublisher = table.getBooleanTopic("Simple Feedforward").publish();
+            }
+            if (config.motionProfileEnabled) {
+              motionProfilePublisher = table.getBooleanTopic("Motion Profile").publish();
+            }
+            if (config.setpointPositionEnabled) {
+              setpointPositionPublisher = table.getDoubleTopic("Setpoint Position (Rotations)").publish();
+            }
+            if (config.setpointVelocityEnabled) {
+              setpointVelocityPublisher = table.getDoubleTopic("Setpoint Velocity (Rotations per Second)").publish();
+            }
+            if (config.feedforwardVoltageEnabled) {
+              feedforwardVoltagePublisher = table.getDoubleTopic("Feedforward Voltage").publish();
+            }
+            if (config.pidOutputVoltageEnabled) {
+              pidOutputVoltagePublisher = table.getDoubleTopic("PID Output (Voltage)").publish();
+            }
+            if (config.outputVoltageEnabled) {
+              outputVoltagePublisher = table.getDoubleTopic("Motor Output Voltage").publish();
+            }
+            if (config.statorCurrentEnabled) {
+              statorCurrentPublisher = table.getDoubleTopic("Stator Current (Amps)").publish();
+            }
+            if (config.temperatureEnabled) {
+              temperaturePublisher = table.getDoubleTopic("Temperature (Celsius)").publish();
+            }
+            if (config.distanceEnabled) {
+              measurementPositionPublisher = table.getDoubleTopic("Measurement Position (Meters)").publish();
+            }
+            if (config.linearVelocityEnabled) {
+              measurementVelocityPublisher = table.getDoubleTopic("Measurement Velocity (Meters per Second)").publish();
+            }
+            if (config.mechanismPositionEnabled) {
+              mechanismPositionPublisher = table.getDoubleTopic("Mechanism Position (Rotations)").publish();
+            }
+            if (config.mechanismVelocityEnabled) {
+              mechanismVelocityPublisher = table.getDoubleTopic("Mechanism Velocity (Rotations per Second)").publish();
+            }
+            if (config.rotorPositionEnabled) {
+              rotorPositionPublisher = table.getDoubleTopic("Rotor Position (Rotations)").publish();
+            }
+            if (config.rotorVelocityEnabled) {
+              rotorVelocityPublisher = table.getDoubleTopic("Rotor Velocity (Rotations per Second)").publish();
+            }
+        }
+        if (table != null) {
+            if (config.mechanismLowerLimitEnabled) {
+                mechanismLowerLimitPublisher.set(mechanismLowerLimit);
+            }
+            if (config.mechanismUpperLimitEnabled) {
+                mechanismUpperLimitPublisher.set(mechanismUpperLimit);
+            }
+            if (config.temperatureLimitEnabled) {
+                temperatureLimitPublisher.set(temperatureLimit);
+            }
+            if (config.velocityControlEnabled) {
+                velocityControlPublisher.set(velocityControl);
+            }
+            if (config.elevatorFeedforwardEnabled) {
+                elevatorFeedforwardPublisher.set(elevatorFeedforward);
+            }
+            if (config.armFeedforwardEnabled) {
+                armFeedforwardPublisher.set(armFeedforward);
+            }
+            if (config.simpleFeedforwardEnabled) {
+                simpleFeedforwardPublisher.set(simpleFeedforward);
+            }
+            if (config.motionProfileEnabled) {
+                motionProfilePublisher.set(motionProfile);
+            }
+            if (config.setpointPositionEnabled) {
+                setpointPositionPublisher.set(setpointPosition);
+            }
+            if (config.setpointVelocityEnabled) {
+                setpointVelocityPublisher.set(setpointVelocity);
+            }
+            if (config.feedforwardVoltageEnabled) {
+                feedforwardVoltagePublisher.set(feedforwardVoltage);
+            }
+            if (config.pidOutputVoltageEnabled) {
+                pidOutputVoltagePublisher.set(pidOutputVoltage);
+            }
+            if (config.outputVoltageEnabled) {
+                outputVoltagePublisher.set(outputVoltage);
+            }
+            if (config.statorCurrentEnabled) {
+                statorCurrentPublisher.set(statorCurrent);
+            }
+            if (config.temperatureEnabled) {
+                temperaturePublisher.set(temperature.in(Celsius));
+            }
+            if (config.distanceEnabled) {
+                measurementPositionPublisher.set(distance.in(Meters));
+            }
+            if (config.linearVelocityEnabled) {
+                measurementVelocityPublisher.set(linearVelocity.in(MetersPerSecond));
+            }
+            if (config.mechanismPositionEnabled) {
+                mechanismPositionPublisher.set(mechanismPosition.in(Rotations));
+            }
+            if (config.mechanismVelocityEnabled) {
+                mechanismVelocityPublisher.set(mechanismVelocity.in(RotationsPerSecond));
+            }
+            if (config.rotorPositionEnabled) {
+                rotorPositionPublisher.set(rotorPosition.in(Rotations));
+            }
+            if (config.rotorVelocityEnabled) {
+                rotorVelocityPublisher.set(rotorVelocity.in(RotationsPerSecond));
+            }
+        }
     }
-  }
 }

--- a/src/main/java/yams/telemetry/SmartMotorControllerTelemetryConfig.java
+++ b/src/main/java/yams/telemetry/SmartMotorControllerTelemetryConfig.java
@@ -1,0 +1,300 @@
+package yams.telemetry;
+
+import yams.motorcontrollers.SmartMotorController;
+
+public class SmartMotorControllerTelemetryConfig {
+    /**
+     * Mechanism lower limit reached.
+     */
+    public boolean mechanismLowerLimitEnabled = false;
+    /**
+     * Mechanism upper limit reached.
+     */
+    public boolean mechanismUpperLimitEnabled = false;
+    /**
+     * Motor temperature cutoff reached.
+     */
+    public boolean temperatureLimitEnabled = false;
+    /**
+     * Velocity PID controller used.
+     */
+    public boolean velocityControlEnabled = false;
+    /**
+     * Elevator feedforward used.
+     */
+    public boolean elevatorFeedforwardEnabled = false;
+    /**
+     * Arm feedforward used.
+     */
+    public boolean armFeedforwardEnabled = false;
+    /**
+     * Simple feedforward used.
+     */
+    public boolean simpleFeedforwardEnabled = false;
+    /**
+     * Motion profiling used.
+     */
+    public boolean motionProfileEnabled = false;
+    /**
+     * Setpoint position given.
+     */
+    public boolean setpointPositionEnabled = false;
+    /**
+     * Setpoint velocity given.
+     */
+    public boolean setpointVelocityEnabled = false;
+    /**
+     * Feedforward voltage supplied to the {@link SmartMotorController}
+     */
+    public boolean feedforwardVoltageEnabled = false;
+    /**
+     * PID Output voltage supplied to the {@link SmartMotorController}
+     */
+    public boolean pidOutputVoltageEnabled = false;
+    /**
+     * Output voltage to the {@link SmartMotorController}
+     */
+    public boolean outputVoltageEnabled = false;
+    /**
+     * Stator current (motor controller output current) to the Motor.
+     */
+    public boolean statorCurrentEnabled = false;
+    /**
+     * Motor temperature.
+     */
+    public boolean temperatureEnabled = false;
+    /**
+     * Mechanism distance.
+     */
+    public boolean distanceEnabled = false;
+    /**
+     * Mechanism linear velocity.
+     */
+    public boolean linearVelocityEnabled = false;
+    /**
+     * Mechanism position.
+     */
+    public boolean mechanismPositionEnabled = false;
+    /**
+     * Mechanism velocity.
+     */
+    public boolean mechanismVelocityEnabled = false;
+    /**
+     * Rotor position.
+     */
+    public boolean rotorPositionEnabled = false;
+    /**
+     * Rotor velocity.
+     */
+    public boolean rotorVelocityEnabled = false;
+
+    /**
+     * Enables the mechanism lower limit logging if available.
+     *
+     * @return {@link SmartMotorControllerTelemetryConfig} for chaining.
+     */
+    public SmartMotorControllerTelemetryConfig withMechanismLowerLimit() {
+        mechanismLowerLimitEnabled = true;
+        return this;
+    }
+
+    /**
+     * Enables the mechanism upper limit logging if available.
+     *
+     * @return {@link SmartMotorControllerTelemetryConfig} for chaining.
+     */
+    public SmartMotorControllerTelemetryConfig withMechanismUpperLimit() {
+        mechanismUpperLimitEnabled = true;
+        return this;
+    }
+
+    /**
+     * Enables the temperature limit logging if available.
+     *
+     * @return {@link SmartMotorControllerTelemetryConfig} for chaining.
+     */
+    public SmartMotorControllerTelemetryConfig withTemperatureLimit() {
+        temperatureLimitEnabled = true;
+        return this;
+    }
+
+    /**
+     * Enables the velocity control mode logging if available.
+     *
+     * @return {@link SmartMotorControllerTelemetryConfig} for chaining.
+     */
+    public SmartMotorControllerTelemetryConfig withVelocityControl() {
+        velocityControlEnabled = true;
+        return this;
+    }
+
+    /**
+     * Enables the elevator feedforward logging if available.
+     *
+     * @return {@link SmartMotorControllerTelemetryConfig} for chaining.
+     */
+    public SmartMotorControllerTelemetryConfig withElevatorFeedforward() {
+        elevatorFeedforwardEnabled = true;
+        return this;
+    }
+
+    /**
+     * Enables the arm feedforward logging if available.
+     *
+     * @return {@link SmartMotorControllerTelemetryConfig} for chaining.
+     */
+    public SmartMotorControllerTelemetryConfig withArmFeedforward() {
+        armFeedforwardEnabled = true;
+        return this;
+    }
+
+    /**
+     * Enables the simple feedforward logging if available.
+     *
+     * @return {@link SmartMotorControllerTelemetryConfig} for chaining.
+     */
+    public SmartMotorControllerTelemetryConfig withSimpleFeedforward() {
+        simpleFeedforwardEnabled = true;
+        return this;
+    }
+
+    /**
+     * Enables the motion profile logging if available.
+     *
+     * @return {@link SmartMotorControllerTelemetryConfig} for chaining.
+     */
+    public SmartMotorControllerTelemetryConfig withMotionProfile() {
+        motionProfileEnabled = true;
+        return this;
+    }
+
+    /**
+     * Enables the setpoint position logging if available.
+     *
+     * @return {@link SmartMotorControllerTelemetryConfig} for chaining.
+     */
+    public SmartMotorControllerTelemetryConfig withSetpointPosition() {
+        setpointPositionEnabled = true;
+        return this;
+    }
+
+    /**
+     * Enables the setpoint velocity logging if available.
+     *
+     * @return {@link SmartMotorControllerTelemetryConfig} for chaining.
+     */
+    public SmartMotorControllerTelemetryConfig withSetpointVelocity() {
+        setpointVelocityEnabled = true;
+        return this;
+    }
+
+    /**
+     * Enables the feedforward voltage logging if available.
+     *
+     * @return {@link SmartMotorControllerTelemetryConfig} for chaining.
+     */
+    public SmartMotorControllerTelemetryConfig withFeedbackVoltage() {
+        feedforwardVoltageEnabled = true;
+        return this;
+    }
+
+    /**
+     * Enables the pid output voltage logging if available.
+     *
+     * @return {@link SmartMotorControllerTelemetryConfig} for chaining.
+     */
+    public SmartMotorControllerTelemetryConfig withPidOutputVoltage() {
+        pidOutputVoltageEnabled = true;
+        return this;
+    }
+
+    /**
+     * Enables the output voltage logging if available.
+     *
+     * @return {@link SmartMotorControllerTelemetryConfig} for chaining.
+     */
+    public SmartMotorControllerTelemetryConfig withOutputVoltage() {
+        outputVoltageEnabled = true;
+        return this;
+    }
+
+    /**
+     * Enables the stator current logging if available.
+     *
+     * @return {@link SmartMotorControllerTelemetryConfig} for chaining.
+     */
+    public SmartMotorControllerTelemetryConfig withStatorCurrent() {
+        statorCurrentEnabled = true;
+        return this;
+    }
+
+    /**
+     * Enables the temperature logging if available.
+     *
+     * @return {@link SmartMotorControllerTelemetryConfig} for chaining.
+     */
+    public SmartMotorControllerTelemetryConfig withTemperature() {
+        temperatureEnabled = true;
+        return this;
+    }
+
+    /**
+     * Enables the distance logging if available.
+     *
+     * @return {@link SmartMotorControllerTelemetryConfig} for chaining.
+     */
+    public SmartMotorControllerTelemetryConfig withDistance() {
+        distanceEnabled = true;
+        return this;
+    }
+
+    /**
+     * Enables the linear velocity logging if available.
+     *
+     * @return {@link SmartMotorControllerTelemetryConfig} for chaining.
+     */
+    public SmartMotorControllerTelemetryConfig withLinearVelocity() {
+        linearVelocityEnabled = true;
+        return this;
+    }
+
+    /**
+     * Enables the mechanism position logging if available.
+     *
+     * @return {@link SmartMotorControllerTelemetryConfig} for chaining.
+     */
+    public SmartMotorControllerTelemetryConfig withMechanismPosition() {
+        mechanismPositionEnabled = true;
+        return this;
+    }
+
+    /**
+     * Enables the mechanism velocity logging if available.
+     *
+     * @return {@link SmartMotorControllerTelemetryConfig} for chaining.
+     */
+    public SmartMotorControllerTelemetryConfig withMechanismVelocity() {
+        mechanismVelocityEnabled = true;
+        return this;
+    }
+
+    /**
+     * Enables the rotor position logging if available.
+     *
+     * @return {@link SmartMotorControllerTelemetryConfig} for chaining.
+     */
+    public SmartMotorControllerTelemetryConfig withRotorPosition() {
+        rotorPositionEnabled = true;
+        return this;
+    }
+
+    /**
+     * Enables the rotor velocity logging if available.
+     *
+     * @return {@link SmartMotorControllerTelemetryConfig} for chaining.
+     */
+    public SmartMotorControllerTelemetryConfig withRotorVelocity() {
+        rotorVelocityEnabled = true;
+        return this;
+    }
+}


### PR DESCRIPTION
Working on resolution for Issue #7 Add telemetryconfig. Functional but hasn't been polished. I plan on making a MechanismTelemetryConfig but when I do I combine that with Issue #8 for the AdvantageScope Tuning. 

Added code examples in the subsystems. 
If withTelemetry and withSpecificTelemetry are both enabled it will default to withSpecificTelemetry. 
withSpecificTelemetry is likely to be renamed before accepting, likely to withTelemetryConfig. 

Images attached of testing with all, none, and some telemetry enabled. 
![Screenshot 2025-06-25 195510](https://github.com/user-attachments/assets/17e9e4f0-4c6d-40e0-b02e-7e3b08e676f5)
![Screenshot 2025-06-25 195510](https://github.com/user-attachments/assets/17e9e4f0-4c6d-40e0-b02e-7e3b08e676f5)
![Screenshot 2025-06-25 200001](https://github.com/user-attachments/assets/22847565-163b-4814-9257-f51e5bbb0895)
![Screenshot 2025-06-25 200001](https://github.com/user-attachments/assets/22847565-163b-4814-9257-f51e5bbb0895)
![Screenshot 2025-06-25 200103](https://github.com/user-attachments/assets/ec32a167-6fc4-483b-beb8-108182c7bac3)
![Screenshot 2025-06-25 200103](https://github.com/user-attachments/assets/ec32a167-6fc4-483b-beb8-108182c7bac3)
